### PR TITLE
add ImageMagick image merge process step

### DIFF
--- a/containers/imagemagick/Dockerfile
+++ b/containers/imagemagick/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG IM_VERSION=7.1.1-3
+ARG LIB_HEIF_VERSION=1.15.1
+ARG LIB_AOM_VERSION=3.6.0
+ARG LIB_WEBP_VERSION=1.3.0
+ARG LIBJXL_VERSION=0.8.1
+
+RUN apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get install -y git make gcc pkg-config autoconf curl g++ cmake clang \
+    # libaom
+    yasm \
+    # libheif
+    libde265-0 libde265-dev libjpeg-turbo8-dev x265 libx265-dev libtool \
+    # libwebp
+    libsdl1.2-dev libgif-dev \
+    # libjxl
+    libbrotli-dev \
+    # IM
+    libpng16-16 libpng-dev libgomp1 ghostscript libxml2-dev libxml2-utils libtiff-dev libfontconfig1-dev libfreetype6-dev fonts-dejavu liblcms2-dev \
+    # Install manually to prevent deleting with -dev packages
+    libxext6 libbrotli1 && \
+    # Building libjxl
+    export CC=clang CXX=clang++ && \
+    git clone -b v${LIBJXL_VERSION} https://github.com/libjxl/libjxl.git --depth 1 --recursive --shallow-submodules && \
+    cd libjxl && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && \
+    cmake --build . -- -j$(nproc) && \
+    cmake --install . && \
+    cd ../../ && \
+    rm -rf libjxl && \
+    ldconfig /usr/local/lib && \
+    # Building libwebp
+    git clone https://chromium.googlesource.com/webm/libwebp && \
+    cd libwebp && git checkout v${LIB_WEBP_VERSION} && \
+    ./autogen.sh && ./configure --enable-shared --enable-libwebpdecoder --enable-libwebpdemux --enable-libwebpmux --enable-static=no && \
+    make && make install && \
+    ldconfig /usr/local/lib && \
+    cd ../ && rm -rf libwebp && \
+    # Building libaom
+    git clone -b v${LIB_AOM_VERSION} --depth 1 https://aomedia.googlesource.com/aom && \
+    mkdir build_aom && \
+    cd build_aom && \
+    cmake ../aom/ -DENABLE_TESTS=0 -DBUILD_SHARED_LIBS=1 && make && make install && \
+    ldconfig /usr/local/lib && \
+    cd .. && \
+    rm -rf aom && \
+    rm -rf build_aom && \
+    # Building libheif
+    curl -L https://github.com/strukturag/libheif/releases/download/v${LIB_HEIF_VERSION}/libheif-${LIB_HEIF_VERSION}.tar.gz -o libheif.tar.gz && \
+    tar -xzvf libheif.tar.gz && cd libheif-${LIB_HEIF_VERSION}/ && ./autogen.sh && ./configure && make && make install && cd .. && \
+    ldconfig /usr/local/lib && \
+    rm -rf libheif-${LIB_HEIF_VERSION} && rm libheif.tar.gz && \
+    # Building ImageMagick
+    git clone -b ${IM_VERSION} --depth 1 https://github.com/ImageMagick/ImageMagick.git && \
+    cd ImageMagick && \
+    ./configure --without-magick-plus-plus --disable-docs --disable-static --with-tiff --with-jxl && \
+    make && make install && \
+    ldconfig /usr/local/lib && \
+    apt-get remove --autoremove --purge -y gcc make cmake clang curl g++ yasm git autoconf pkg-config libpng-dev libjpeg-turbo8-dev libde265-dev libx265-dev libxml2-dev libtiff-dev libfontconfig1-dev libfreetype6-dev liblcms2-dev libsdl1.2-dev libgif-dev libbrotli-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /ImageMagick
+
+WORKDIR /imgs
+
+ENTRYPOINT [""]

--- a/containers/imagemagick/Makefile
+++ b/containers/imagemagick/Makefile
@@ -1,0 +1,9 @@
+version ?= v0.1
+
+all: build push
+
+build:
+	docker build --tag storytek/imagemagick:${version} .
+	
+push:
+	docker push storytek/imagemagick:${version}

--- a/containers/stable-diffusion/Makefile
+++ b/containers/stable-diffusion/Makefile
@@ -3,7 +3,7 @@ version ?= v0.1
 all: build push
 
 build:
-	docker build --tag evanfloden/stable-diffusion-nf:${version} .
+	docker build --tag storytek/stable-diffusion-nf:${version} .
 	
 push:
-	docker push evanfloden/stable-diffusion-nf:${version}
+	docker push storytek/stable-diffusion-nf:${version}

--- a/containers/stable-diffusion/conda.yml
+++ b/containers/stable-diffusion/conda.yml
@@ -1,0 +1,18 @@
+name: stable-diffusion-nf
+channels:
+  - defaults
+  - conda-forge
+  - pytorch-lts
+  - anaconda
+  - huggingface
+dependencies:
+  - huggingface_hub
+  - transformers
+  - diffusers==0.2.4
+  - pytorch
+  - torchvision
+  - tqdm
+  - pillow
+  - matplotlib
+  - numpy
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,2 +1,25 @@
-docker.enabled = true
-process.container = 'evanfloden/stable-diffusion-nf:v0.1'
+docker {
+    enabled = true
+}
+
+process {
+
+     withName:INFERENCE {
+	container = 'storytek/stable-diffusion-nf:latest'
+	memory = '6.GB'
+	cpus = 1
+	accelerator = 1
+	containerOptions = '-e NVIDIA_REQUIRE_CUDA=cuda>=9.0 NVIDIA_DRIVER_CAPABILITIES=all'
+     }
+
+
+     withName:MERGE {
+         container = 'storytek/imagemagick:latest'
+     }
+}
+
+dag {
+    enabled = true
+    file = 'pipeline_dag.html'
+    overwrite = true
+}


### PR DESCRIPTION
Hi Evan. This pull request contains changes to main.nf, nextflow.config, and the Dockerfile for a new Imagemagick container in the containers directory. The changes to nextflow.config are to accomodate the new container and to avoid the need to override nextflow config settings in the Tower pipeline definition. Presently the containers are being pulled from my public Docker Hub repo. If you prefer to pull them from your Dockerhub account, please build the Imagemagick container first. I did not use an existing public Imagemagick container because most have "convert" as the entry point, and I wanted a null entry point because we need to invoke the "montage" command instead of convert. I encountered difficulties overriding the entry point in the nextflow.config when using public containers. 